### PR TITLE
fix(nui/vehicle): Use numbers instead of boolean

### DIFF
--- a/web/src/components/vehicle.tsx
+++ b/web/src/components/vehicle.tsx
@@ -152,11 +152,11 @@ const Vehicle: React.FC<VehicleProps> = ({ vehicle, index, garage }) => {
                                 </Paper>
                             </SimpleGrid>
                             <Button.Group >
-                                <Button fullWidth onClick={SpawnVehicle} disabled={!vehicle.stored} leftIcon={<IconCarGarage size={17} />} variant="light" size='xs' >{lang.GarageMenu5}</Button>
+                                <Button fullWidth onClick={SpawnVehicle} disabled={vehicle.stored == 0} leftIcon={<IconCarGarage size={17} />} variant="light" size='xs' >{lang.GarageMenu5}</Button>
                                 {vehicle.isOwner && (
                                     <>
-                                        <Button fullWidth onClick={ShowMenuKeys} variant="light" size='xs' leftIcon={<IconKey size={17} />}>{lang.GarageMenu6}</Button>
-                                        <Button fullWidth onClick={SetBlip} variant="light" size='xs' leftIcon={<IconMapSearch size={17} />} disabled={vehicle.stored}>{lang.GarageMenu7}</Button>
+                                        <Button fullWidth onClick={ShowMenuKeys} variant="light" size='xs' leftIcon={<IconKey size={17} />} disabled={vehicle.stored == 1}>{lang.GarageMenu6}</Button>
+                                        <Button fullWidth onClick={SetBlip} variant="light" size='xs' leftIcon={<IconMapSearch size={17} />} disabled={vehicle.stored == 1}>{lang.GarageMenu7}</Button>
                                     </>
                                 )}
 


### PR DESCRIPTION
## Overview
This pull request updates the code in the NUI vehicle component to use numbers (0 and 1) instead of boolean values for the vehicle.stored property. The change ensures that the button states accurately reflect the stored status of the vehicle using numeric comparisons.

## Problem Adressed
The previous implementation used boolean values to control the `disabled` state of the buttons, which may not align with the stored status of the vehicle being represented as numbers (0 for not stored and 1 for stored). By switching to numeric comparisons, the code is more robust and accurately reflects the intended logic for enabling/disabling buttons based on the vehicle's stored status.

## Changes Made
1. Updated the disabled property of the buttons to use numeric comparison (vehicle.stored == 0 or vehicle.stored == 1).
2. Modified the following buttons:
    - Spawn Vehicle Button: Disabled when vehicle.stored == 0.
    - Show Menu Keys Button: Disabled when vehicle.stored == 1.
    - Set Blip Button: Disabled when vehicle.stored == 1.

## Testing
- Verified that the buttons correctly enable or disable based on the numeric value of `vehicle.stored`.
- Tested the UI to ensure the changes do not affect the functionality of the buttons and that they behave as expected.

Please review the changes and provide feedback. Thank you!